### PR TITLE
fix: Render sublists indented by two spaces

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 mkdocs mkdocs-material
-#        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Build
       run: |
         mkdocs build -c -f mkdocs-en.yml

--- a/docs/en/3-Pipelines/Kubeflow-Pipelines.md
+++ b/docs/en/3-Pipelines/Kubeflow-Pipelines.md
@@ -64,7 +64,8 @@ _components_ are connected, such as:
 3. ...
 
 <!-- prettier-ignore -->
-!!! example "Example of a pipeline" Here's an example
+!!! example "Example of a pipeline"
+    Here's an example
 
         #!/bin/python3
         dsl.pipeline(

--- a/docs/en/Collaboration.md
+++ b/docs/en/Collaboration.md
@@ -13,7 +13,8 @@ can share the scope of who you're sharing with **No one** v.s. **My Team** v.s.
 
 <!-- prettier-ignore -->
 ??? question "What is the difference between a bucket and a folder?"
-    Buckets are like Network Storage. See the [Storage section](/Storage) section for more discussion of the differences between these two ideas.
+    Buckets are like Network Storage. See the [Storage section](/Storage)
+    section for more discussion of the differences between these two ideas.
 
 The way that **Private** v.s. **Team** based access is configured is with
 **namespaces**. So we start by talking about Kubeflow and Kubeflow namespaces.

--- a/docs/fr/3-Pipelines/Kubeflow-Pipelines.md
+++ b/docs/fr/3-Pipelines/Kubeflow-Pipelines.md
@@ -65,25 +65,26 @@ exemple :
 3. ...
 
 <!-- prettier-ignore -->
-??? example "Exemple d'un pipeline"
+!!! example "Exemple d'un pipeline"
     Voici un exemple :
 
-    ```python
-    #!/bin/python3
-    dsl.pipeline(name="Estimer Pi",
-        description="Estimer Pi au moyen d'un modèle Map-Reduce")
-    def compute_pi():
-        # Créer un "exemple" d'opération pour chaque valeur de départ transmise au pipeline
-        seeds = (1,2,3,4,5,6,7,8,9,10) sample_ops = [sample_op(seed) for seed in seeds]
+        #!/bin/python3
+        dsl.pipeline(name="Estimer Pi",
+            description="Estimer Pi au moyen d'un modèle Map-Reduce")
+        def compute_pi():
+            # Créer un "exemple" d'opération pour chaque valeur de départ
+            # transmise au pipeline
+            seeds = (1,2,3,4,5,6,7,8,9,10)
+            sample_ops = [sample_op(seed) for seed in seeds]
 
-        # Obtenir les résultats avant de les transmettre à deux pipelines distincts
-        # Les résultats sont extraits des fichiers output_file.json et
-        # sont disponibles à partir des instances sample_op par l'entremise de l'attribut .outputs
-        outputs = [s.outputs['output'] for s in sample_ops]
+            # Obtenir les résultats avant de les transmettre à deux pipelines
+            # distincts. Les résultats sont extraits des fichiers
+            # `output_file.json` et sont disponibles à partir des instances
+            # `sample_op` par l'entremise de l'attribut `.outputs`.
+            outputs = [s.outputs['output'] for s in sample_ops]
 
-        _generate_plot_op = generate_plot_op(outputs)
-        _average_op = average_op(outputs)
-    ```
+            _generate_plot_op = generate_plot_op(outputs)
+            _average_op = average_op(outputs)
 
     Vous pouvez trouver le pipeline complet dans
     [l'exemple `map-reduce-pipeline`](https://github.com/StatCan/jupyter-notebooks).

--- a/mkdocs-en.yml
+++ b/mkdocs-en.yml
@@ -27,6 +27,7 @@ markdown_extensions:
   - attr_list
   - admonition
   - codehilite
+  - mdx_truly_sane_lists
   - pymdownx.details
 
 extra:

--- a/mkdocs-fr.yml
+++ b/mkdocs-fr.yml
@@ -31,6 +31,7 @@ markdown_extensions:
   - attr_list
   - admonition
   - codehilite
+  - mdx_truly_sane_lists
   - pymdownx.details
 
 extra:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+mdx-truly-sane-lists==1.2
+mkdocs==1.1.2
+mkdocs-material==5.4.0


### PR DESCRIPTION
Adds the mdx_truly_sane_lists extension so that two-space indented
sublists are rendered as such.

Fixes #156