### PR TITLE
update Github Workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,7 @@ on: push
 jobs:
   spelling-en:
     name: Spelling (en)
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -16,6 +17,7 @@ jobs:
 
   spelling-fr:
     name: Spelling (fr)
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Add `continue-on-error: true` to both `spelling-en` and `spelling-fr` because we don't want spelling to be a blocker especially when `mdspell` flags all kinds of false positives.