### PR TITLE
docs: add a depreciation banner

### DIFF
--- a/mkdocs-dev.yml
+++ b/mkdocs-dev.yml
@@ -26,6 +26,10 @@ theme:
   palette:
     primary: yellow
     accent: blue
+
+  # Injects depreciation banner 
+  custom_dir: overrides-dev
+
 nav:
   - Features:
     - Getting Started: getting-started/index.md

--- a/overrides-dev/main.html
+++ b/overrides-dev/main.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block header %}
+<!-- Injects depreciation banner over all pages -->
+<div style="background-color: #ffdddd; color: #a00; padding: 1rem; text-align: center; font-weight: bold; font-size: 0.75rem;">
+    ⚠️ This development documentation is deprecated. Please visit <a href="https://zone.pages.cloud.statcan.ca/docs/dev/" style="color: #a00; text-decoration: underline;">The Zone dev documentation site</a>.
+</div>
+{{ super() }}
+{% endblock %}


### PR DESCRIPTION
## Context
Co-op students had trouble with finding the best place with onboarding documentation, this AAW dev site was provided but doesn't have the latest details.

## Description
The development contributions documentation is outdated, a depreciation banner has been added (only for the dev docs) and users are directed to the new dev docs site for developers working on The Zone

## Changes
A banner at the top of each dev docs page will direct users to the [latest documentation site here](https://zone.pages.cloud.statcan.ca/docs/dev/)

<img src="https://github.com/user-attachments/assets/99083921-86ba-4268-afac-54f9ad5ac4e7" alt=""/>